### PR TITLE
Tweak Gridfinity rugged box rendering

### DIFF
--- a/gridfinity/rugged-box/rugged-box-gridfinity.scad
+++ b/gridfinity/rugged-box/rugged-box-gridfinity.scad
@@ -269,7 +269,8 @@ module gridfinity_top_base() {
         for (i = [0:1:Length - 1])
         translate([0, (i - Length / 2 + 0.5) * l_grid, 0])
         gridfinity_top_base_strip(i);
-        gridfinity_rectangle(adjust=1.6);
+        linear_extrude(height=h_base * 2)
+        square([width + 1.6, length + 1.6], center=true);
     }
 }
 

--- a/gridfinity/rugged-box/rugged-box-gridfinity.scad
+++ b/gridfinity/rugged-box/rugged-box-gridfinity.scad
@@ -290,7 +290,6 @@ module custom_top() {
     difference () {
         union() {
             rbox_body();
-            render(convexity=4)
             custom_top_interior_grid();
         }
         if (Gridfinity_Stackable) {

--- a/gridfinity/rugged-box/rugged-box-gridfinity.scad
+++ b/gridfinity/rugged-box/rugged-box-gridfinity.scad
@@ -198,7 +198,7 @@ module gridfinity_bottom_base(hole=false) {
 
 module rbox_interior_base(height = h_base * 2) {
     intersection() {
-        rbox_interior();
+        rbox_interior(cut_height=height);
         rbox_for_interior()
         linear_extrude(height=height)
         square([width * 2, length * 2], center=true);

--- a/rugged-box/rugged-box-library.scad
+++ b/rugged-box/rugged-box-library.scad
@@ -226,11 +226,11 @@ module rbox_body_modifier_volume() {
     _box_body_modifier_volume();
 }
 
-module rbox_interior() {
+module rbox_interior(cut_height=0) {
     _box_color()
     render(convexity=4) {
         _box_extrude()
-        _box_interior_shape();
+        _box_interior_shape(cut_height);
         rbox_for_interior()
         _box_center_base($b_inner_height);
     }
@@ -875,7 +875,7 @@ module _box_wall_shape(reinforced=false) {
     square([$b_wall_thickness * 2/3, min($b_outer_height, $b_wall_thickness)]);
 }
 
-module _box_interior_shape() {
+module _box_interior_shape(cut_height=0) {
     intersection() {
         difference() {
             translate([$b_wall_thickness / 2, -$b_wall_thickness / 2])
@@ -885,7 +885,7 @@ module _box_interior_shape() {
         translate([0, $b_wall_thickness])
         square([
             $b_corner_radius + $b_edge_radius,
-            $b_outer_height - $b_wall_thickness
+            (cut_height > 0) ? cut_height : $b_outer_height - $b_wall_thickness
         ]);
     }
 }

--- a/rugged-box/rugged-box-library.scad
+++ b/rugged-box/rugged-box-library.scad
@@ -1390,20 +1390,18 @@ module _box_top_grip() {
         mirror([0, 1, 0])
         translate([0, $b_inner_length / 2 - $b_corner_radius, 0])
         rotate([90, 0, 90])
+        // hull() creates grip
+        hull()
         for (mz = [0:1:1])
         mirror([0, 0, mz])
         translate([lip_position, 0]) {
-            // Grip
-            linear_extrude(height=grip_half_length)
-            _round_shape($b_edge_radius)
-            _box_top_grip_shape();
             // End caps
             translate([0, 0, grip_half_length])
             translate([-$b_edge_radius, 0, 0])
             scale([1, 1, end_caps_visible ? 1 : ($b_rib_width / top_grip_depth / 2)])
             rotate([270, 270, 0])
             rotate_extrude(angle=90)
-            translate([$b_edge_radius, 0])
+            translate([$b_edge_radius + 0.001, 0])
             _round_shape($b_edge_radius)
             _box_top_grip_shape();
         }

--- a/rugged-box/rugged-box-library.scad
+++ b/rugged-box/rugged-box-library.scad
@@ -884,7 +884,7 @@ module _box_interior_shape() {
         }
         translate([0, $b_wall_thickness])
         square([
-            $b_corner_radius + $b_edge_radius * 2,
+            $b_corner_radius + $b_edge_radius,
             $b_outer_height - $b_wall_thickness
         ]);
     }


### PR DESCRIPTION
This may improve rendering stability when using the stable version of OpenSCAD