### PR TITLE
Update Gridfinity rebuilt bins tab sizes and configured renders

### DIFF
--- a/gridfinity/rebuilt-bins/SConscript
+++ b/gridfinity/rebuilt-bins/SConscript
@@ -17,19 +17,37 @@ Params = namedtuple(
         "scoop",
         "d_wall",
         "d_div",
+        "a_tab",
+        "d_tabh",
         "h_cut_extra",
         "h_cut_extra_single",
         "args",
     ),
-    defaults=(2, 2, 3, 1, 1, "default", 1, 1, 0.95, 1.2, 1.6, 2.0, N()),
+    defaults=(
+        2,
+        2,
+        3,
+        1,
+        1,
+        "default",
+        1,
+        1,
+        0.95,
+        1.2,
+        20,
+        14.265,
+        1.6,
+        2.0,
+        N(),
+    ),
 )
 
 model = "bin.scad"
 
 bins = [
     [Params(divx=1, divy=1, d_wall=1.6)],
-    [Params(divx=2, divy=1)],
-    [Params(divx=2, divy=2)],
+    [Params(divx=2, divy=1, a_tab=30, d_tabh=13.4725)],
+    [Params(divx=2, divy=2, a_tab=30, d_tabh=13.4725)],
     [Params(divx=3, divy=1)],
     [Params(divx=3, divy=2)],
     [Params(divx=4, divy=1)],
@@ -37,7 +55,18 @@ bins = [
     [Params(divx=5, divy=1)],
     [Params(divx=6, divy=1)],
     [Params(divx=6, divy=1, gridz=1.5, h_cut_extra=1.8)],
-    [Params(divx=1, divy=1, gridz=6, scoop=0.5, d_wall=1.6, h_cut_extra=1.4)],
+    [
+        Params(
+            divx=1,
+            divy=1,
+            gridz=6,
+            scoop=0.5,
+            d_wall=1.6,
+            a_tab=36,
+            d_tabh=12.68,
+            h_cut_extra=1.4,
+        )
+    ],
     [
         Params(
             divx=2,
@@ -46,6 +75,8 @@ bins = [
             scoop=0.5,
             d_wall=1.6,
             d_div=1.6,
+            a_tab=30,
+            d_tabh=13.4725,
             h_cut_extra=1.4,
         )
     ],
@@ -57,10 +88,14 @@ bins = [
             scoop=0.5,
             d_wall=1.6,
             d_div=1.6,
+            a_tab=30,
+            d_tabh=13.4725,
             h_cut_extra=1.4,
         )
     ],
-    [Params(Compartment_Style="6p")],
+    [Params(gridz=3, Compartment_Style="3p", a_tab=30, d_tabh=13.4725)],
+    [Params(gridz=6, Compartment_Style="3p", a_tab=30, d_tabh=13.4725)],
+    [Params(Compartment_Style="6p", a_tab=30, d_tabh=13.4725)],
     [
         Params(
             4,

--- a/gridfinity/rebuilt-bins/bin.scad
+++ b/gridfinity/rebuilt-bins/bin.scad
@@ -13,9 +13,9 @@ include <gridfinity-rebuilt-openscad/gridfinity-rebuilt-utility.scad>
 
 // [Default Value Overrides] */
 // Tab size
-d_tabh = 14.265; // [15.85: Default, 14.265: 90% -- for reduced tab angle, 12.68: 80%]
+d_tabh = 14.265; // [15.85: Default, 14.265: 90% -- for bridged tab angle, 13.4725: 85% -- for reduced tab angle, 12.68: 80%]
 // Tab angle
-a_tab = 20; // [36: Default, 20: Reduced]
+a_tab = 20; // [36: Default, 30: Reduced, 20: Bridged]
 // Outer wall thickness
 d_wall = 0.95; // [0.95: Default, 1.2: 3 lines, 1.6: 4 lines, 2.6: Full thickness -- desk tray style]
 // Divider wall thickness
@@ -37,7 +37,7 @@ h_cut_extra = 1.6; // [0: Default, 1.8: 2 bottom layers, 1.6: 3 bottom layers, 1
 // Additional interior depth for single-grid pockets -- best used with h_cut_extra set to 2 bottom layers
 h_cut_extra_single = 2.0; // [0: Default, 2.0: Most, 1.4: Some]
 
-Compartment_Style = "default"; // [default: Default -- use compartment settings below, "6p": half and half half/single pockets]
+Compartment_Style = "default"; // [default: Default -- use compartment settings below, "6p": half and half half/single pockets, "3p": double and single pockets]
 
 /* [Linear Compartments] */
 // number of X Divisions (set to zero to have solid bin)
@@ -318,6 +318,13 @@ module block_cutter(x,y,w,h,t,s) {
     }
 }
 
+module compartments_custom_3p() {
+    for (x = [0:1:gridx/2-0.1], y = [0:2:gridy-0.1])
+    cut(x, y, 1, 2);
+    for (x = [gridx/2:1:gridx-0.1], y = [0:1:gridy-0.1])
+    cut(x, y, 1, 1);
+}
+
 module compartments_custom_6p() {
     for (x = [0:1:gridx-0.1], y = [0:1:gridy/2-0.1])
     cut(x, y, 1, 1);
@@ -344,6 +351,8 @@ module compartments_cut() {
                 orientation=c_orientation
             );
         }
+    } else if (Compartment_Style == "3p") {
+        compartments_custom_3p();
     } else if (Compartment_Style == "6p") {
         compartments_custom_6p();
     }


### PR DESCRIPTION
This adds a new custom pocket style "3p"